### PR TITLE
Fix DATA filename in Makefile (1.0.0 -> 0.1.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # pgGit Makefile - Minimal Version
 
 EXTENSION = pggit
-DATA = pggit--1.0.0.sql
+DATA = pggit--0.1.3.sql
 REGRESS = 
 
 PG_CONFIG = pg_config


### PR DESCRIPTION
## Description
changed version number within filename in Makefile since make install failed

## Related Issue
Didn't create bug. Got this issue installing.
```
install: cannot stat './/pggit--1.0.0.sql': No such file or directory
make: *** [/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk:240: install] Error 1
```

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature)
- [ ] Documentation update

## Testing
changed name and `make install` ran without errors

### Test Environment
- PostgreSQL version: 16
- OS: postgres:16 Docker container

### Test Results
```
root@d2f02e00cf4c:/pggit# make install
/bin/mkdir -p '/usr/share/postgresql/16/extension'
/bin/mkdir -p '/usr/share/postgresql/16/extension'
/usr/bin/install -c -m 644 .//pggit.control '/usr/share/postgresql/16/extension/'
/usr/bin/install -c -m 644 .//pggit--0.1.3.sql  '/usr/share/postgresql/16/extension/'
root@d2f02e00cf4c:/pggit#
```

## Checklist
- [x] My code follows the style guide
One-liner fix

## Breaking Changes
n/a

## Documentation
n/a

## Screenshots (if applicable)
n/a