### PR TITLE
docs: add PostgreSQL 18 to supported versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ There are many ways to contribute to pgGit:
 
 Before you begin, make sure you have:
 
-- **PostgreSQL 15, 16, or 17** installed
+- **PostgreSQL 15, 16, 17, or 18** installed
 - **C compiler** (gcc or clang)
 - **PostgreSQL development headers** (`postgresql-server-dev-*` package)
 - **Git** for version control

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ pgGit enhances your development process without touching production.
 
 - ✅ **62 Tests** - 100% pass rate (51 passed + 11 xfails)
 - ✅ **Quality Score** - 9.8/10 comprehensive quality assessment (Phase 1-3 complete)
-- ✅ **PostgreSQL Support** - Versions 15, 16, and 17
+- ✅ **PostgreSQL Support** - Versions 15, 16, 17, and 18
 - ✅ **Known Limitations** - 11 test environment xfails documented with workarounds
 - ✅ **Comprehensive Docs** - API reference, operations runbook, security guides
 - ✅ **CI/CD Ready** - Exit code 0, professional test infrastructure

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -28,7 +28,7 @@ This guide covers installing pgGit on **development and staging databases**. pgG
 - At least 100MB free space for pgGit schemas
 
 **Tested Versions**:
-- PostgreSQL 12, 13, 14, 15, 16, 17
+- PostgreSQL 12, 13, 14, 15, 16, 17, 18
 - Docker PostgreSQL images
 - Local PostgreSQL installations
 


### PR DESCRIPTION
## Description
Updated documentation to include PostgreSQL 18 as a supported version.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature)
- [x] Documentation update

## Testing
Tested installation, extension loading, and ran full test suite in postgres:18 Docker container.

### Test Environment
- PostgreSQL version: 18
- OS: postgres:18 Docker container (Debian)

### Test Results
```
# Installation
root@7358f6ae0dde:/pggit# make install
/bin/mkdir -p '/usr/share/postgresql/18/extension'
/bin/mkdir -p '/usr/share/postgresql/18/extension'
/usr/bin/install -c -m 644 .//pggit.control '/usr/share/postgresql/18/extension/'
/usr/bin/install -c -m 644 .//pggit--0.1.3.sql  '/usr/share/postgresql/18/extension/'

# Extension loading
psql -U postgres -c "CREATE EXTENSION pggit CASCADE;"
NOTICE:  installing required extension "pgcrypto"
CREATE EXTENSION

# Test suite
Test Results:
  Passed: 12
  Failed: 1
  Total: 13
  Duration: 2s
Success Rate: 92%
```

Note: The single test failure (https://github.com/evoludigit/pgGit/issues/12 Data Branching Tests) is a pre-existing issue — same test fails on PG17. 

## Checklist
- [x] My code follows the style guide
- [ ] I've run `make lint` — N/A, docs only
- [ ] I've added tests for my changes — N/A, docs only
- [x] All tests pass (`make test`) — 92%, same as PG17
- [x] I've updated documentation
- [ ] I've added COMMENT ON for new functions — N/A
- [ ] I've updated CHANGELOG.md — left for maintainer
- [x] No new TODO/FIXME without issue

## Breaking Changes
None

## Documentation
Updated:
- README.md
- CONTRIBUTING.md
- docs/INSTALLATION.md

## Additional Notes
Happy to add PG18 to the CI test matrix in a follow-up PR if desired:
- `.github/workflows/tests.yml`
- `docs/CI_CD.md`
- `docs/testing/CHAOS_ENGINEERING.md`
- `tests/README.md`
- `tests/chaos/TEST_STATUS.md`
- `tests/chaos/TESTING.md`