### PR TITLE
fix(audit): Correct parameter order in audited_operation function

### DIFF
--- a/sql/075_audit_log.sql
+++ b/sql/075_audit_log.sql
@@ -104,8 +104,8 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION pggit.audited_operation(
     p_operation_name TEXT,
     p_operation_type TEXT,
-    p_parameters JSONB DEFAULT NULL,
-    p_operation_sql TEXT
+    p_operation_sql TEXT,
+    p_parameters JSONB DEFAULT NULL
 )
 RETURNS JSONB AS $$
 DECLARE


### PR DESCRIPTION
## Description
Fix parameter ordering in `pggit.audited_operation()` function. Parameters with DEFAULT values must come after required parameters in PostgreSQL.

## Related Issue
N/A (discovered during testing)

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature)
- [ ] Documentation update

## Testing
Verified that `CREATE EXTENSION pggit CASCADE` no longer fails with parameter ordering error.

### Test Environment
- PostgreSQL version: 17
- OS: Docker container (postgres:17)

### Test Results
```
Extension creates successfully after fix
```

## Checklist
- [x] My code follows the style guide
- [ ] I've run `make lint`
- [ ] I've added tests for my changes
- [x] All tests pass (`make test`)
- [ ] I've updated documentation
- [ ] I've added COMMENT ON for new functions
- [ ] I've updated CHANGELOG.md
- [x] No new TODO/FIXME without issue

## Breaking Changes
N/A

## Documentation
N/A

## Files Changed
- `sql/075_audit_log.sql`

🤖 Generated with [Claude Code](https://claude.ai/code)