### PR TITLE
fix(test): Correct assertions in data branching tests

### DIFF
--- a/tests/test-data-branching.sql
+++ b/tests/test-data-branching.sql
@@ -59,7 +59,8 @@ BEGIN
     SELECT COUNT(*) INTO v_main_count FROM test_products WHERE price = 9.99;
     
     PERFORM pggit.switch_branch('feature/price-update');
-    SELECT COUNT(*) INTO v_branch_count FROM test_products WHERE price = 10.989;
+    -- Note: DECIMAL(10,2) rounds 9.99 * 1.1 = 10.989 to 10.99
+    SELECT COUNT(*) INTO v_branch_count FROM test_products WHERE price = 10.99;
     
     IF v_main_count = 1 AND v_branch_count = 1 THEN
         RAISE NOTICE 'PASS: Data properly isolated between branches';
@@ -101,7 +102,7 @@ BEGIN
     );
     
     -- Measure storage after branching
-    SELECT SUM(size) INTO v_storage_after
+    SELECT SUM(total_size) INTO v_storage_after
     FROM pggit.branch_storage_stats
     WHERE branch_name IN ('main', 'feature/cow-test');
     


### PR DESCRIPTION
## Description
Fix incorrect test assertions in `test-data-branching.sql`:
1. **DECIMAL precision**: `9.99 * 1.1 = 10.989` but `DECIMAL(10,2)` rounds to `10.99`
2. **Column name**: `branch_storage_stats` table has `total_size` column, not `size`

## Related Issue
N/A (discovered during testing)

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature)
- [ ] Documentation update

## Testing
Tests now use correct expected values.

### Test Environment
- PostgreSQL version: 17
- OS: Docker container (postgres:17)

### Test Results
```
Test assertions now match actual computed values
```

## Checklist
- [x] My code follows the style guide
- [ ] I've run `make lint`
- [ ] I've added tests for my changes
- [x] All tests pass (`make test`)
- [ ] I've updated documentation
- [ ] I've added COMMENT ON for new functions
- [ ] I've updated CHANGELOG.md
- [x] No new TODO/FIXME without issue

## Breaking Changes
N/A

## Documentation
N/A

## Files Changed
- `tests/test-data-branching.sql`

🤖 Generated with [Claude Code](https://claude.ai/code)